### PR TITLE
feat. Learn mounts when entering the game

### DIFF
--- a/conf/mod-mounts-on-account.conf.dist
+++ b/conf/mod-mounts-on-account.conf.dist
@@ -41,4 +41,12 @@ moa.enable.cast = false
 
 moa.enable.learn = true
 
+#
+#    moa.enable.learn.on.login
+#        Description: The player learns the mounts, when he/she enters the server.
+#        Default:     false - Disabled
+#
+
+moa.enable.learn.on.login = false
+
 ########################################


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- Add a way to learn spells from mounts, when the player enters the world.
- In order to learn it, you need to have an option in the .conf, which is disabled by default.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Windows 10
- In-game


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Enable the option in the .conf file.
2. You create a character, and learn the 2 main equipments, level 20 and level 40.
3. Then, you exit the game, and re-enter. By doing so, you will learn all the spells of the mounts, which were stored in the database, corresponding to your faction or the neutral ones.
