### PR TITLE
fix. Preventing null pointers in item_template

### DIFF
--- a/src/MOAMain.cpp
+++ b/src/MOAMain.cpp
@@ -56,6 +56,9 @@ public:
         {
             QueryResult resultEntry = WorldDatabase.Query("SELECT `entry` FROM `item_template` WHERE `spellid_2`={};", spellID);
 
+            if (!resultEntry)
+                return;
+
             ItemTemplate const* itemTemplate = sObjectMgr->GetItemTemplate((*resultEntry)[0].Get<int32>());
 
             if (!itemTemplate)


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
- When a spell was learned from the class instructor or any other instructor, lag and loss of stability occurred on the server. Then, reviewing the SQL query, notice that the spells, of the instructors, are not associated with any item_template, so, if the query is empty, what we must do is return.
- Although perhaps there is another module, which also teaches mounts on their own, it does not have a mechanism like this, where the mounts are stored in a table, and in that way, we can also learn neutral mounts, being able to share them with people. of the other faction.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->
- Closes

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->
- Windows 10
- In-game


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. When learning a spell, on any instructor, prior to this change, the emulator practically stopped responding, the lag increased, and even caused a crash.
2. After this change, you can learn several class spells, from several classes, and at no time did I notice that the performance of the emulator could be affected. Perhaps there is another method, however, the module is still being worked on, so it will continue to undergo changes.