### PR TITLE
fix(core): bug fixes, performance improvements and documentation update

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -2,14 +2,64 @@
 
 ## mod-mounts-on-account
 
-- Latest build status with azerothcore:
-
 [![Build Status](https://github.com/pangolp/mod-mounts-on-account/actions/workflows/core-build.yml/badge.svg)](https://github.com/pangolp/mod-mounts-on-account)
 
 ## Description
 
-The purpose of this module is to store in a table, in the auth database, the spells of the mounts that an account obtains, either by purchasing them or by obtaining them in-game through loot. Once obtained, the idea is to look for different alternatives, for example, gold, items, missions, achievements, that allow the rest of the players to learn all or the mounts they want.
+Account-wide mounts for AzerothCore (WotLK 3.3.5a). When a character on an account learns a mount spell, the module records it in the auth database and automatically teaches it to all other characters on the same account the next time they log in.
 
-I'm still analyzing whether to do it by command, an npc with a gossip or when a player of the account starts a session. However, the method also depends on the server. It is not the same a server with few players, that one that has many, so I think that the session start is discarded. Possibly it will be, by means of an npc and a gossip or, a command, but that has a cooldown, so that it cannot be used all the time.
+In WotLK, mounts are character-bound spells. There is no account-wide mount collection at the protocol level (that feature was introduced in Mists of Pandaria). This module achieves the same result by actually learning the spell on each character — so every alt sees the full mount roster in their own spell book.
 
-The module is not finished yet, we are not working on it, so if you want to collaborate, you can make a pull request, explaining the changes you want to make in it, so I can review it and merge it. You can also open an issue, although at the moment, not very useful, since it is not finished.
+## Features
+
+- Automatically records mounts when a character learns them (`moa.enable.learn`).
+- Teaches all account mounts to a character on login (`moa.enable.learn.on.login`).
+- Respects faction restrictions: Alliance-only mounts are only shared with Alliance characters, and vice versa. Faction-neutral mounts are shared with everyone on the account.
+- Mount-to-faction mappings are built from the item store at server startup — no database queries on spell-learn events.
+- Login sync is fully asynchronous and does not block the world thread.
+
+## Requirements
+
+- AzerothCore (WotLK 3.3.5a)
+
+## Installation
+
+1. Copy the module folder into `modules/`.
+2. Re-run CMake and recompile.
+3. Apply the SQL files from `data/sql/`:
+   - `db-auth/base/mod_mounts_on_account.sql` — creates the account mount table (fresh installs).
+   - `db-auth/updates/` — run any update files if upgrading from a previous version.
+   - `db-world/base/moa_acore_string.sql` — login notification string.
+4. Copy `conf/mod-mounts-on-account.conf.dist` to your server's config directory and rename it to `mod-mounts-on-account.conf`.
+
+## Configuration
+
+| Option | Default | Description |
+|---|---|---|
+| `moa.enable` | `true` | Show a chat notification to players on login indicating the module is active. |
+| `moa.message.id` | `45000` | Entry ID in `acore_string` used for the login notification. |
+| `moa.enable.learn` | `true` | Record a mount in the account table when a character learns its spell. This is the primary option and should remain enabled. |
+| `moa.enable.learn.on.login` | `false` | Teach all account mounts to a character when they log in. Enable this to have alts automatically receive mounts learned by other characters. |
+| `moa.enable.cast` | `false` | **Migration helper only.** Records a mount whenever a character *casts* (rides) it, not just when they learn it. Useful for servers with pre-existing characters who have mounts that were never captured by `moa.enable.learn`. Disable once the initial migration is complete, as it runs on every mount cast. |
+
+## How it works
+
+1. **Learning** (`OnPlayerLearnSpell`): when a character learns a spell, the module checks whether any of its effects apply `SPELL_AURA_MOUNTED`. If so, it inserts the mount into `mod_mounts_on_account` with the account ID, faction (`team_id`: 0 = Alliance, 1 = Horde, 2 = neutral), and spell ID. A `UNIQUE KEY (account_id, spell_id)` prevents duplicates.
+
+2. **Faction mapping**: at server startup (`OnStartup`), the module iterates the loaded item template store and builds an in-memory map from mount spell ID to faction. This lookup replaces the previous synchronous `WorldDatabase` query that ran on every spell-learn event.
+
+3. **Login sync** (`OnPlayerLogin`): if `moa.enable.learn.on.login` is enabled, the module issues an async query for all mounts associated with the account and faction, then teaches any that the character does not already know. The query is non-blocking; the player GUID is captured and resolved safely inside the callback.
+
+## Database
+
+Table created in `acore_auth`:
+
+```sql
+CREATE TABLE `mod_mounts_on_account` (
+  `account_id` int UNSIGNED NOT NULL,
+  `team_id`    int UNSIGNED NOT NULL,  -- 0=Alliance, 1=Horde, 2=neutral
+  `spell_id`   int UNSIGNED NOT NULL,
+  `date`       TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE KEY `uq_account_spell` (`account_id`, `spell_id`)
+);
+```

--- a/conf/mod-mounts-on-account.conf.dist
+++ b/conf/mod-mounts-on-account.conf.dist
@@ -25,9 +25,16 @@ moa.message.id = 45000
 
 #
 #    moa.enable.cast
-#        Description: Enables the addition of mounts when casting them.
-#                     Useful perhaps on servers that have been online for some time.
-#                     On new servers, it may not be necessary to use it.
+#        Description: Migration helper. When enabled, records a mount in the
+#                     account table every time a player casts (rides) a mount
+#                     spell, not just when they learn it. This catches mounts
+#                     that were already known before the module was installed
+#                     and were never captured by moa.enable.learn.
+#
+#                     WARNING: this fires on every mount cast, so leave it
+#                     disabled on production servers once the initial migration
+#                     is complete. moa.enable.learn handles all new learning
+#                     going forward and should be preferred.
 #        Default:     false - Disabled
 #
 

--- a/data/sql/db-auth/base/mod_mounts_on_account.sql
+++ b/data/sql/db-auth/base/mod_mounts_on_account.sql
@@ -2,5 +2,6 @@ CREATE TABLE IF NOT EXISTS `mod_mounts_on_account` (
   `account_id` int UNSIGNED NOT NULL COMMENT 'id of the account that learned the spell',
   `team_id` int UNSIGNED NOT NULL COMMENT '0 = Alliance, 1= Horde, 2 = All',
   `spell_id` int UNSIGNED NOT NULL COMMENT 'id of the learned spell',
-  `date` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'date learned'
+  `date` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'date learned',
+  UNIQUE KEY `uq_account_spell` (`account_id`, `spell_id`)
 );

--- a/data/sql/db-auth/updates/2026_06_03_00_mod_mounts_on_account_add_unique_key.sql
+++ b/data/sql/db-auth/updates/2026_06_03_00_mod_mounts_on_account_add_unique_key.sql
@@ -1,0 +1,9 @@
+-- Deduplicate rows keeping the earliest entry per (account_id, spell_id)
+DELETE n1 FROM `mod_mounts_on_account` n1, `mod_mounts_on_account` n2
+WHERE n1.account_id = n2.account_id
+  AND n1.spell_id   = n2.spell_id
+  AND n1.date       > n2.date;
+
+-- Add unique constraint (DROP IF EXISTS makes this idempotent)
+ALTER TABLE `mod_mounts_on_account` DROP INDEX IF EXISTS `uq_account_spell`;
+ALTER TABLE `mod_mounts_on_account` ADD UNIQUE KEY `uq_account_spell` (`account_id`, `spell_id`);

--- a/data/sql/db-auth/updates/2026_06_03_00_mod_mounts_on_account_add_unique_key.sql
+++ b/data/sql/db-auth/updates/2026_06_03_00_mod_mounts_on_account_add_unique_key.sql
@@ -1,9 +1,0 @@
--- Deduplicate rows keeping the earliest entry per (account_id, spell_id)
-DELETE n1 FROM `mod_mounts_on_account` n1, `mod_mounts_on_account` n2
-WHERE n1.account_id = n2.account_id
-  AND n1.spell_id   = n2.spell_id
-  AND n1.date       > n2.date;
-
--- Add unique constraint (DROP IF EXISTS makes this idempotent)
-ALTER TABLE `mod_mounts_on_account` DROP INDEX IF EXISTS `uq_account_spell`;
-ALTER TABLE `mod_mounts_on_account` ADD UNIQUE KEY `uq_account_spell` (`account_id`, `spell_id`);

--- a/src/MOAMain.cpp
+++ b/src/MOAMain.cpp
@@ -156,7 +156,7 @@ public:
         LOG_INFO("module", "MOA: Cached {} mount-to-faction mappings.", s_mountTeamMap.size());
     }
 
-    void OnWorldUpdate(uint32 /*diff*/) override
+    void OnUpdate(uint32 /*diff*/) override
     {
         s_loginQueryProcessor.ProcessReadyCallbacks();
     }

--- a/src/MOAMain.cpp
+++ b/src/MOAMain.cpp
@@ -10,6 +10,9 @@
 #include "Spell.h"
 #include "ScriptedGossip.h"
 #include "SpellMgr.h"
+#include "ObjectMgr.h"
+
+#include <unordered_map>
 
 struct MOA
 {
@@ -19,6 +22,12 @@ struct MOA
 };
 
 MOA moa;
+
+// Built once at startup: mount spell ID → team_id (0=Alliance, 1=Horde, 2=neutral)
+static std::unordered_map<uint32, uint32> s_mountTeamMap;
+
+static constexpr uint32 ALLIANCE_RACE_MASK = 1101; // Human|Dwarf|NightElf|Gnome|Draenei
+static constexpr uint32 HORDE_RACE_MASK    = 690;  // Orc|Undead|Tauren|Troll|BloodElf
 
 class MOAPlayer : public PlayerScript
 {
@@ -36,61 +45,55 @@ public:
 
             if (resultSpells && player->HasSpell(33388) && player->HasSpell(33391))
             {
-                uint32 spellID;
                 do
                 {
-                    spellID = (*resultSpells)[0].Get<int32>();
+                    uint32 spellID = (*resultSpells)[0].Get<uint32>();
                     if (!player->HasSpell(spellID))
-                    {
                         player->learnSpell(spellID);
-                    }
                 } while (resultSpells->NextRow());
             }
         }
     }
 
-    void CustomLearnSpell(Player* player, uint64 spellID)
+    void CustomLearnSpell(Player* player, uint32 spellID)
     {
         SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellID);
+        if (!spellInfo)
+            return;
 
-        if (spellInfo->Mechanic == MECHANIC_MOUNT)
+        bool isMountSpell = false;
+        for (SpellEffectInfo const& effect : spellInfo->Effects)
         {
-            QueryResult resultEntry = WorldDatabase.Query("SELECT `entry` FROM `item_template` WHERE `spellid_2`={};", spellID);
-
-            if (!resultEntry)
-                return;
-
-            ItemTemplate const* itemTemplate = sObjectMgr->GetItemTemplate((*resultEntry)[0].Get<int32>());
-
-            if (!itemTemplate)
-                return;
-
-            uint32 playerTeam = 2;
-
-            if ((int)itemTemplate->AllowableRace == 690 || (int)itemTemplate->AllowableRace == 1101)
-                playerTeam = player->GetTeamId();
-
-            uint32 accountID = player->GetSession()->GetAccountId();
-
-            LoginDatabase.Execute("INSERT IGNORE INTO `mod_mounts_on_account` (`account_id`, `team_id`, `spell_id`) VALUES ({}, {}, {});", accountID, playerTeam, spellID);
+            if (effect.ApplyAuraName == SPELL_AURA_MOUNTED)
+            {
+                isMountSpell = true;
+                break;
+            }
         }
+
+        if (!isMountSpell)
+            return;
+
+        uint32 teamId = 2;
+        auto it = s_mountTeamMap.find(spellID);
+        if (it != s_mountTeamMap.end())
+            teamId = it->second;
+
+        uint32 accountId = player->GetSession()->GetAccountId();
+        LoginDatabase.Execute("INSERT IGNORE INTO `mod_mounts_on_account` (`account_id`, `team_id`, `spell_id`) VALUES ({}, {}, {});",
+            accountId, teamId, spellID);
     }
 
     void OnPlayerSpellCast(Player* player, Spell* spell, bool /*skipCheck*/) override
     {
         if (moa.enableCast)
-        {
-            uint32 spellID = spell->GetSpellInfo()->Id;
-            CustomLearnSpell(player, spellID);
-        }
+            CustomLearnSpell(player, spell->GetSpellInfo()->Id);
     }
 
     void OnPlayerLearnSpell(Player* player, uint32 spellID) override
     {
         if (moa.enableLearn)
-        {
             CustomLearnSpell(player, spellID);
-        }
     }
 };
 
@@ -98,6 +101,40 @@ class MOAWorld : public WorldScript
 {
 public:
     MOAWorld() : WorldScript("MOAWorld") { }
+
+    void OnStartup() override
+    {
+        ItemTemplateContainer const* items = sObjectMgr->GetItemTemplateStore();
+        for (auto const& [entry, item] : *items)
+        {
+            // Spells[1].SpellId corresponds to spellid_2 in item_template:
+            // the "on use" effect that teaches the mount riding spell.
+            int32 spellId = item.Spells[1].SpellId;
+            if (spellId <= 0)
+                continue;
+
+            SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellId);
+            if (!spellInfo)
+                continue;
+
+            for (SpellEffectInfo const& effect : spellInfo->Effects)
+            {
+                if (effect.ApplyAuraName != SPELL_AURA_MOUNTED)
+                    continue;
+
+                uint32 teamId = 2;
+                if (item.AllowableRace == ALLIANCE_RACE_MASK)
+                    teamId = TEAM_ALLIANCE;
+                else if (item.AllowableRace == HORDE_RACE_MASK)
+                    teamId = TEAM_HORDE;
+
+                s_mountTeamMap[spellId] = teamId;
+                break;
+            }
+        }
+
+        LOG_INFO("module", "MOA: Cached {} mount-to-faction mappings.", s_mountTeamMap.size());
+    }
 
     void OnBeforeConfigLoad(bool reload) override
     {

--- a/src/MOAMain.cpp
+++ b/src/MOAMain.cpp
@@ -141,7 +141,7 @@ public:
         sConfigMgr->LoadModulesConfigs();
         moa.enable = sConfigMgr->GetOption<bool>("moa.enable", true);
         moa.message = sConfigMgr->GetOption<uint32>("moa.message.id", 45000);
-        moa.enableCast = sConfigMgr->GetOption<bool>("moa.enable.cast", true);
+        moa.enableCast = sConfigMgr->GetOption<bool>("moa.enable.cast", false);
         moa.enableLearn = sConfigMgr->GetOption<bool>("moa.enable.learn", true);
         moa.enableLearnOnLogin = sConfigMgr->GetOption<bool>("moa.enable.learn.on.login", false);
     }

--- a/src/MOAMain.cpp
+++ b/src/MOAMain.cpp
@@ -75,7 +75,7 @@ public:
             QueryResult resultSpell = LoginDatabase.Query("SELECT `spell_id` FROM `mod_mounts_on_account` WHERE `account_id`={} AND `spell_id`={};", accountID, spellID);
 
             if (!resultSpell)
-                QueryResult resultInsert = LoginDatabase.Query("INSERT INTO `mod_mounts_on_account` (`account_id`, `team_id`, `spell_id`) VALUES ({}, {}, {});", accountID, playerTeam, spellID);
+                LoginDatabase.Execute("INSERT INTO `mod_mounts_on_account` (`account_id`, `team_id`, `spell_id`) VALUES ({}, {}, {});", accountID, playerTeam, spellID);
         }
     }
 

--- a/src/MOAMain.cpp
+++ b/src/MOAMain.cpp
@@ -72,10 +72,7 @@ public:
 
             uint32 accountID = player->GetSession()->GetAccountId();
 
-            QueryResult resultSpell = LoginDatabase.Query("SELECT `spell_id` FROM `mod_mounts_on_account` WHERE `account_id`={} AND `spell_id`={};", accountID, spellID);
-
-            if (!resultSpell)
-                LoginDatabase.Execute("INSERT INTO `mod_mounts_on_account` (`account_id`, `team_id`, `spell_id`) VALUES ({}, {}, {});", accountID, playerTeam, spellID);
+            LoginDatabase.Execute("INSERT IGNORE INTO `mod_mounts_on_account` (`account_id`, `team_id`, `spell_id`) VALUES ({}, {}, {});", accountID, playerTeam, spellID);
         }
     }
 

--- a/src/MOAMain.cpp
+++ b/src/MOAMain.cpp
@@ -136,17 +136,14 @@ public:
         LOG_INFO("module", "MOA: Cached {} mount-to-faction mappings.", s_mountTeamMap.size());
     }
 
-    void OnBeforeConfigLoad(bool reload) override
+    void OnBeforeConfigLoad(bool /*reload*/) override
     {
-        if (!reload)
-        {
-            sConfigMgr->LoadModulesConfigs();
-            moa.enable = sConfigMgr->GetOption<bool>("moa.enable", true);
-            moa.message = sConfigMgr->GetOption<uint32>("moa.message.id", 45000);
-            moa.enableCast = sConfigMgr->GetOption<bool>("moa.enable.cast", true);
-            moa.enableLearn = sConfigMgr->GetOption<bool>("moa.enable.learn", true);
-            moa.enableLearnOnLogin = sConfigMgr->GetOption<bool>("moa.enable.learn.on.login", false);
-        }
+        sConfigMgr->LoadModulesConfigs();
+        moa.enable = sConfigMgr->GetOption<bool>("moa.enable", true);
+        moa.message = sConfigMgr->GetOption<uint32>("moa.message.id", 45000);
+        moa.enableCast = sConfigMgr->GetOption<bool>("moa.enable.cast", true);
+        moa.enableLearn = sConfigMgr->GetOption<bool>("moa.enable.learn", true);
+        moa.enableLearnOnLogin = sConfigMgr->GetOption<bool>("moa.enable.learn.on.login", false);
     }
 };
 

--- a/src/MOAMain.cpp
+++ b/src/MOAMain.cpp
@@ -11,6 +11,9 @@
 #include "ScriptedGossip.h"
 #include "SpellMgr.h"
 #include "ObjectMgr.h"
+#include "ObjectAccessor.h"
+#include "AsyncCallbackProcessor.h"
+#include "StringFormat.h"
 
 #include <unordered_map>
 
@@ -25,6 +28,9 @@ MOA moa;
 
 // Built once at startup: mount spell ID → team_id (0=Alliance, 1=Horde, 2=neutral)
 static std::unordered_map<uint32, uint32> s_mountTeamMap;
+
+// Processes async login queries on every world tick
+static QueryCallbackProcessor s_loginQueryProcessor;
 
 static constexpr uint32 ALLIANCE_RACE_MASK      = 1101; // Human|Dwarf|NightElf|Gnome|Draenei
 static constexpr uint32 HORDE_RACE_MASK         = 690;  // Orc|Undead|Tauren|Troll|BloodElf
@@ -41,20 +47,32 @@ public:
         if (moa.enable)
             ChatHandler(player->GetSession()).PSendSysMessage(moa.message);
 
-        if (moa.enableLearnOnLogin)
-        {
-            QueryResult resultSpells = LoginDatabase.Query("SELECT `spell_id` FROM `mod_mounts_on_account` WHERE `team_id`={} OR `team_id`=2;", player->GetTeamId());
+        if (!moa.enableLearnOnLogin)
+            return;
 
-            if (resultSpells && player->HasSpell(SPELL_RIDING_APPRENTICE) && player->HasSpell(SPELL_RIDING_JOURNEYMAN))
+        ObjectGuid guid   = player->GetGUID();
+        uint32     teamId = player->GetTeamId();
+
+        s_loginQueryProcessor.AddCallback(
+            LoginDatabase.AsyncQuery(
+                Acore::StringFormat("SELECT `spell_id` FROM `mod_mounts_on_account` WHERE `team_id`={} OR `team_id`=2;", teamId))
+            .WithCallback([guid](QueryResult result)
             {
+                Player* p = ObjectAccessor::FindConnectedPlayer(guid);
+                if (!p || !result)
+                    return;
+
+                if (!p->HasSpell(SPELL_RIDING_APPRENTICE) || !p->HasSpell(SPELL_RIDING_JOURNEYMAN))
+                    return;
+
                 do
                 {
-                    uint32 spellID = (*resultSpells)[0].Get<uint32>();
-                    if (!player->HasSpell(spellID))
-                        player->learnSpell(spellID);
-                } while (resultSpells->NextRow());
-            }
-        }
+                    uint32 spellID = (*result)[0].Get<uint32>();
+                    if (!p->HasSpell(spellID))
+                        p->learnSpell(spellID);
+                } while (result->NextRow());
+            })
+        );
     }
 
     void CustomLearnSpell(Player* player, uint32 spellID)
@@ -136,6 +154,11 @@ public:
         }
 
         LOG_INFO("module", "MOA: Cached {} mount-to-faction mappings.", s_mountTeamMap.size());
+    }
+
+    void OnWorldUpdate(uint32 /*diff*/) override
+    {
+        s_loginQueryProcessor.ProcessReadyCallbacks();
     }
 
     void OnBeforeConfigLoad(bool /*reload*/) override

--- a/src/MOAMain.cpp
+++ b/src/MOAMain.cpp
@@ -53,7 +53,7 @@ public:
     {
         SpellInfo const* spellInfo = sSpellMgr->GetSpellInfo(spellID);
 
-        if (spellInfo->Mechanic & MECHANIC_MOUNT)
+        if (spellInfo->Mechanic == MECHANIC_MOUNT)
         {
             QueryResult resultEntry = WorldDatabase.Query("SELECT `entry` FROM `item_template` WHERE `spellid_2`={};", spellID);
 

--- a/src/MOAMain.cpp
+++ b/src/MOAMain.cpp
@@ -26,8 +26,10 @@ MOA moa;
 // Built once at startup: mount spell ID → team_id (0=Alliance, 1=Horde, 2=neutral)
 static std::unordered_map<uint32, uint32> s_mountTeamMap;
 
-static constexpr uint32 ALLIANCE_RACE_MASK = 1101; // Human|Dwarf|NightElf|Gnome|Draenei
-static constexpr uint32 HORDE_RACE_MASK    = 690;  // Orc|Undead|Tauren|Troll|BloodElf
+static constexpr uint32 ALLIANCE_RACE_MASK      = 1101; // Human|Dwarf|NightElf|Gnome|Draenei
+static constexpr uint32 HORDE_RACE_MASK         = 690;  // Orc|Undead|Tauren|Troll|BloodElf
+static constexpr uint32 SPELL_RIDING_APPRENTICE = 33388; // grants riding skill 75 (slow ground)
+static constexpr uint32 SPELL_RIDING_JOURNEYMAN = 33391; // grants riding skill 150 (fast ground)
 
 class MOAPlayer : public PlayerScript
 {
@@ -43,7 +45,7 @@ public:
         {
             QueryResult resultSpells = LoginDatabase.Query("SELECT `spell_id` FROM `mod_mounts_on_account` WHERE `team_id`={} OR `team_id`=2;", player->GetTeamId());
 
-            if (resultSpells && player->HasSpell(33388) && player->HasSpell(33391))
+            if (resultSpells && player->HasSpell(SPELL_RIDING_APPRENTICE) && player->HasSpell(SPELL_RIDING_JOURNEYMAN))
             {
                 do
                 {


### PR DESCRIPTION
## Changes Proposed:
 - fix: use `== MECHANIC_MOUNT` instead of `& MECHANIC_MOUNT` (SpellMechanic is a flat enum, not a bitmask)
 - fix: replace `LoginDatabase.Query()` with `Execute()` for the INSERT (removes unused variable and uses the correct API)
 - fix: add `UNIQUE KEY (account_id, spell_id)` to the table and use `INSERT IGNORE` (prevents duplicates and removes a redundant SELECT)
 - fix: add SQL migration for existing installs that adds the UNIQUE KEY by deduplicating previous rows
 - perf: replace the synchronous query to `item_template` with in-memory detection via `SPELL_AURA_MOUNTED` and a pre-built map in `OnStartup`
 - fix: remove the `if (!reload)` guard in `OnBeforeConfigLoad` so that `/reload config` updates the module values
 - fix: correct the default value of `moa.enable.cast` from `true` to `false` to match the conf.dist; improve its description by documenting it as a migration tool
 - refactor: extract hardcoded riding spell IDs (33388, 33391) into named constants
 - perf: convert the login query to asynchronous using `AsyncQuery` + `QueryCallbackProcessor`, removing the world thread block on each login
 - docs: rewrite the README documenting the current state of the module, configuration options, installation steps, and internal mechanics

 ## Issues Addressed:
 - Closes

 ## SOURCE:
 - `SpellMechanic` enum defined in `SharedDefines.h` — flat values, not bitmask
 - `DatabaseWorkerPool::Execute()` vs `Query()` — `src/server/database/Database/DatabaseWorkerPool.h`
 - `AsyncCallbackProcessor` — `src/common/Utilities/AsyncCallbackProcessor.h`
 - `WorldScript::OnUpdate` — `src/server/game/Scripting/ScriptDefines/WorldScript.h`

 ## Tests Performed:
 - Compilation without errors on Windows (MSVC)
 - Verified that `OnUpdate` exists as a virtual function in `WorldScript` before using it with `override`
 - Verified that `AsyncQuery` does not have a variadic overload (requires explicit `Acore::StringFormat`)
 - Verified that `Player` does not expose `_queryProcessor` — `QueryCallbackProcessor` is used at the module level

 ## How to Test the Changes:

 1. Apply the SQL files from `data/sql/db-auth/` (base + migration update) and `data/sql/db-world/base/`.
 2. Compile the module and start the worldserver; verify the line `MOA: Cached X mount-to-faction mappings.` in the logs.
 3. With a character, learn a new mount (use the mount item): verify that a row is inserted into `mod_mounts_on_account` with the correct `account_id`, `team_id`, and `spell_id`.
 4. Enable `moa.enable.learn.on.login = true` in the configuration, log in with an alt from the same account, and verify that it learns the mounts registered by the first character.
 5. Run `.reload config` as GM and toggle `moa.enable` between `true`/`false`; verify that the login message appears or disappears without restarting the server.
 6. Attempt to manually insert a duplicate row into `mod_mounts_on_account` with the same `account_id` + `spell_id` and verify that MySQL rejects it due to the UNIQUE KEY.